### PR TITLE
Add RuntimeError to exceptions for gpg

### DIFF
--- a/figgypy/decrypt.py
+++ b/figgypy/decrypt.py
@@ -100,13 +100,13 @@ def gpg_decrypt(cfg, gpg_config=None):
             gpg_config = {}
             defaults = {'homedir': '~/.gnupg/'}
             env_fields = {'homedir': 'FIGGYPY_GPG_HOMEDIR',
-                            'binary': 'FIGGYPY_GPG_BINARY',
-                            'keyring': 'FIGGYPY_GPG_KEYRING'}
+                          'binary': 'FIGGYPY_GPG_BINARY',
+                          'keyring': 'FIGGYPY_GPG_KEYRING'}
             for k, v in env_fields.items():
                 gpg_config[k] = env_or_default(v, defaults[k] if k in defaults else None)
         try:
             gpg = gnupg.GPG(**gpg_config)
-        except OSError:
+        except (OSError, RuntimeError):
             log.exception('Failed to configure gpg. Will be unable to decrypt secrets.')
         return decrypt(cfg)
     return cfg


### PR DESCRIPTION
If no perms on gpg homedir and error is generated that prevents
continuation. In some cases, you want to continue since you may not be
using gpg. This way, we continue but log that secrets won't be decrypted.
