### PR TITLE
Add call to staticmethod _find_file

### DIFF
--- a/figgypy/config.py
+++ b/figgypy/config.py
@@ -146,7 +146,7 @@ class Config(object):
 
     @config_file.setter
     def config_file(self, config_file):
-        self._load_file(config_file)
+        self._load_file(self._find_file(config_file))
         self._config_file = config_file
         self._post_load_process()
 


### PR DESCRIPTION
This was borked in the major point update. Just needed to be called.