### PR TITLE
Feature/parameter store

### DIFF
--- a/figgypy/decrypt.py
+++ b/figgypy/decrypt.py
@@ -237,8 +237,8 @@ def ssm_decrypt(cfg, aws_config=None):
         elif isinstance(obj, dict):
             if '_ssm' in obj:
                 try:
-                    res = client.get_parameter(obj['_ssm'], WithDecryption=True)
-                    obj = n(res['Value'])
+                    res = client.get_parameter(Name=obj['_ssm'], WithDecryption=True)
+                    obj = n(res['Parameter']['Value'])
                 except ClientError as err:
                     if 'AccessDeniedException' in err.args[0]:
                         log.warning('Unable to decrypt %s. Parameter does not exist or no access', obj['_ssm'])
@@ -255,5 +255,5 @@ def ssm_decrypt(cfg, aws_config=None):
         client = aws.client('ssm')
     except NoRegionError:
         log.info('Missing or invalid aws configuration. Will not be able to unpack KMS secrets.')
-        return cfg
+    return decrypt(cfg)
 

--- a/figgypy/utils.py
+++ b/figgypy/utils.py
@@ -64,12 +64,22 @@ def ssm_store_parameter(name, value, key=None, aws_config=None):
     aws_config = aws_config or {}
     aws = boto3.session.Session(**aws_config)
     client =  aws.client('ssm')
-    client.put_parameter(
-        Name=name,
-        Value=value,
-        KeyId=key,
-        Overwrite=True,
-        Description="Figgypy created/updated parameter",
-        Type="SecureString",
-    )
+    if key:
+        client.put_parameter(
+            Name=name,
+            Value=value,
+            KeyId=key,
+            Overwrite=True,
+            Description="Figgypy created/updated parameter",
+            Type="SecureString",
+        )
+    else:
+        client.put_parameter(
+            Name=name,
+            Value=value,
+            Overwrite=True,
+            Description="Figgypy created/updated parameter",
+            Type="SecureString",
+        )
+
     return name

--- a/figgypy/utils.py
+++ b/figgypy/utils.py
@@ -42,3 +42,33 @@ def kms_encrypt(value, key, aws_config=None):
     enc_res = client.encrypt(KeyId=key,
                              Plaintext=value)
     return n(b64encode(enc_res['CiphertextBlob']))
+
+def ssm_store_parameter(name, value, key=None, aws_config=None):
+    """Encrypt and value with KMS key.
+
+    Args:
+        name (str): name to store value under
+        value (str): value to encrypt
+        key (optional[str]): key id of kms key to use. if not passed in account
+            default key will be used.
+        aws_config (optional[dict]): aws credentials
+            dict of arguments passed into boto3 session
+            example:
+                aws_creds = {'aws_access_key_id': aws_access_key_id,
+                             'aws_secret_access_key': aws_secret_access_key,
+                             'region_name': 'us-east-1'}
+
+    Returns:
+        str: name of parameter stored
+    """
+    aws_config = aws_config or {}
+    aws = boto3.session.Session(**aws_config)
+    client =  aws.client('ssm')
+    client.put_parameter(
+        Name=name,
+        Description="Figgypy created/updated parameter",
+        Value=value,
+        KeyId=key,
+        Overwrite=True,
+    )
+    return name

--- a/figgypy/utils.py
+++ b/figgypy/utils.py
@@ -66,9 +66,10 @@ def ssm_store_parameter(name, value, key=None, aws_config=None):
     client =  aws.client('ssm')
     client.put_parameter(
         Name=name,
-        Description="Figgypy created/updated parameter",
         Value=value,
         KeyId=key,
         Overwrite=True,
+        Description="Figgypy created/updated parameter",
+        Type="SecureString",
     )
     return name


### PR DESCRIPTION
Allow configs to have a 
{'component': {'key': {'_ssm': 'name of parameter to get'}}}
section which would cause

This implementation uses [flat](http://boto3.readthedocs.io/en/latest/reference/services/ssm.html#SSM.Client.get_parameter) parameter stores as opposed to [pathed](http://boto3.readthedocs.io/en/latest/reference/services/ssm.html#SSM.Client.get_parameters_by_path) parameters, although I think there is a lot of potential for doing that, I would just like to chat w/ you about how you would think that feature would look.  

Still need to validate this and write some tests, but I wanted to see if this was something you thought would fit in into figgypy. 